### PR TITLE
#34 1.4.0 Rule files

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -51,7 +51,7 @@ from . import save_load, model, operators, panels, preferences
 bl_info = {
     'name': 'BLint',
     'author': 'Spencer Magnusson',
-    'version': (1, 3, 3),
+    'version': (1, 4, 0),
     'blender': (3, 6, 0),
     'description': 'Custom project linting',
     'location': 'Scene',

--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -3,7 +3,7 @@ schema_version = "1.0.0"
 # Example of manifest file for a Blender extension
 # Change the values according to your extension
 id = "blint"
-version = "1.3.3"
+version = "1.4.0"
 name = "BLint"
 tagline = "Project-level quality checks for Blender"
 maintainer = "Spencer Magnusson <semagnum+blenderextensions@gmail.com>"

--- a/external_rule_template.py
+++ b/external_rule_template.py
@@ -1,0 +1,72 @@
+"""Template file rule.
+
+If you would like to test this rule, add it to your BLint config with the following:
+
+{
+    "description": "(script) Unapplied scale on modified object",
+    "enabled": true,
+    "rule_file": "C:\\PATH\\TO\\external_rule_template.py"
+}
+
+"""
+
+import bpy
+from mathutils import Matrix
+
+
+def get_issue_objects():
+    """Not required, just a convenience method to get the issue-related list of datablocks."""
+    return [
+        my_object
+        for my_object in bpy.data.objects
+        if tuple(my_object.scale) != (1.0, 1.0, 1.0) and any(m.type in {'BEVEL', 'SOLIDIFY'} for m in my_object.modifiers)
+    ]
+
+
+def get_issues():
+    """Template function to retrieve and display issues.
+
+    Returns:
+        A list[dict] representing each issue, with each element as:
+        {
+            'description': 'A string used as the issue label',
+            'severity_icon': 'str in ['ERROR', INFO']',
+            'category_icon': 'Icon name found in Blender',
+            'fix_expr': 'str (see below)'
+        }
+
+        The fix_expr can be:
+            - empty, meaning no fix
+            - Python code in str form, just like BLint's default usage of fix_expr
+            - a unique argument to pass to fix_issues() to identify which issue to fix, in this case the object's name
+    """
+    return [
+        {
+            'description': my_object.name + ': unapplied scale on modified object',
+            'severity_icon': 'INFO',
+            'category_icon': 'MODIFIER',
+            'fix_expr': my_object.name
+        }
+        for my_object in get_issue_objects()
+    ]
+
+
+def fix_issues(*args):
+    """Template function to fix issues. If not provided, will default to the issue's own fix_expr.
+
+    Passing a unique argument, like a datablock name, will prevent IndexErrors when running fixes one after the other.
+
+    Args:
+        *args: single element, a "key" to a given issue, in this case the object's name.
+
+    """
+    obj_name = args[0]
+    if obj_name not in [obj.name for obj in get_issue_objects()]:
+        return
+
+    obj = bpy.data.objects[obj_name]
+    mat = obj.matrix_local
+    _, _, scale = mat.decompose()
+    mat_scale = Matrix.LocRotScale(None, None, scale)
+    obj.data.transform(mat_scale)
+    obj.scale = 1, 1, 1

--- a/model/lint_issue.py
+++ b/model/lint_issue.py
@@ -37,6 +37,8 @@ class LintIssue(bpy.types.PropertyGroup):
     """Name of Blender icon to represent the category of the issue's rule (meshes, animation, etc.)."""
     fix_expr: bpy.props.StringProperty(name='Fix', default='')
     """String representation of Python code that will fix the issue."""
+    rule_file: bpy.props.StringProperty(name='Rule File', default='')
+    """Path to rule file containing fix."""
 
     def draw(self, layout):
         """Draws the issue in a panel."""

--- a/model/lint_issue.py
+++ b/model/lint_issue.py
@@ -37,7 +37,7 @@ class LintIssue(bpy.types.PropertyGroup):
     """Name of Blender icon to represent the category of the issue's rule (meshes, animation, etc.)."""
     fix_expr: bpy.props.StringProperty(name='Fix', default='')
     """String representation of Python code that will fix the issue."""
-    rule_file: bpy.props.StringProperty(name='Rule File', default='')
+    rule_file: bpy.props.StringProperty(name='Rule File', default='', subtype='FILE_PATH')
     """Path to rule file containing fix."""
 
     def draw(self, layout):

--- a/model/lint_rule.py
+++ b/model/lint_rule.py
@@ -87,7 +87,8 @@ class LintRule(bpy.types.PropertyGroup):
         name='Rule File',
         description=('Python file with functions to find and fix issues.\n'
                      'If provided, only the rule description and enabled toggle will be used. The rest are ignored'),
-        default=''
+        default='',
+        subtype='FILE_PATH',
     )
 
     def check_for_errors(self) -> list[str]:

--- a/model/lint_rule.py
+++ b/model/lint_rule.py
@@ -15,13 +15,24 @@
 
 from __future__ import annotations
 
+import importlib
 import logging
+import os.path
 
 import bpy
 
 from ..icon_gen import get_icon_enum, get_severity_enum
 
 log = logging.getLogger(__name__)
+
+
+def import_from_file(file_path):
+    loader = importlib.machinery.SourceFileLoader('custom_rule_module', file_path)
+    spec = importlib.util.spec_from_loader('custom_rule_module', loader)
+    custom_rule_module = importlib.util.module_from_spec(spec)
+    loader.exec_module(custom_rule_module)
+
+    return custom_rule_module
 
 
 class LintRule(bpy.types.PropertyGroup):
@@ -72,6 +83,12 @@ class LintRule(bpy.types.PropertyGroup):
                                                           'in its description (can reference data iteration variable)',
                                               default='')
     """Python expression that evaluates to an identifying label used with the issue description in the UI."""
+    rule_file: bpy.props.StringProperty(
+        name='Rule File',
+        description=('Python file with functions to find and fix issues.\n'
+                     'If provided, only the rule description and enabled toggle will be used. The rest are ignored'),
+        default=''
+    )
 
     def check_for_errors(self) -> list[str]:
         """Validates ``LintRule`` properties.
@@ -85,10 +102,18 @@ class LintRule(bpy.types.PropertyGroup):
             issues.append('Category icon cannot be empty')
         if self.severity_icon == '':
             issues.append('Severity icon cannot be empty')
-        if self.issue_expr == '':
-            issues.append('Issue expression cannot be empty')
-        if self.iterable_expr != '' and self.iterable_var == '':
-            issues.append('Iteration variable cannot be empty when using data iteration')
+        if self.rule_file == '':
+            if self.issue_expr == '':
+                issues.append('Issue expression cannot be empty')
+            if self.iterable_expr != '' and self.iterable_var == '':
+                issues.append('Iteration variable cannot be empty when using data iteration')
+        elif not os.path.isfile(bpy.path.abspath(self.rule_file)):
+            issues.append('Rule file does not exist')
+        else:
+            rule_module = import_from_file(bpy.path.abspath(self.rule_file))
+            if not hasattr(rule_module, 'get_issues') or not callable(rule_module.get_issues):
+                issues.append('Rule file\'s "get_issues()" does not exist')
+
         return issues
 
     def copy(self, other_rule: LintRule) -> LintRule:
@@ -183,20 +208,40 @@ class LintRule(bpy.types.PropertyGroup):
         sub_row.label(text='', icon=self.category_icon)
         sub_row.label(text=self.description)
 
+    def get_issues_from_file(self):
+        rule_file_path = bpy.path.abspath(self.rule_file)
+        if not os.path.isfile(rule_file_path):
+            log.error('Rule file not found: {}'.format(rule_file_path))
+            return []
+
+        rule_module = import_from_file(rule_file_path)
+        if not hasattr(rule_module, 'get_issues') or not callable(rule_module.get_issues):
+            log.error('get_issues() function not found in rule file: {}'.format(rule_file_path))
+            return []
+
+        issues = rule_module.get_issues()
+
+        if hasattr(rule_module, 'fix_issues') and callable(rule_module.fix_issues):
+            issues = [dict(issue, **{'rule_file': self.rule_file}) for issue in issues]
+
+        return issues
+
     def get_issues(self) -> list[dict]:
         """Generates and returns a list of issues that violate rules."""
+        result = []
         if self.enabled:
-            if self.iterable_expr:
-                issues = []
-                for idx, identifier in enumerate(self.get_iterative_list()):
-                    issue = {
+            if self.rule_file:
+                result = self.get_issues_from_file()
+            elif self.iterable_expr:
+                result = [
+                    {
                         'description': self.generate_description(idx),
                         'severity_icon': self.severity_icon,
                         'category_icon': self.category_icon,
                         'fix_expr': self.generate_fix(idx) if self.fix_expr else ''
                     }
-                    issues.append(issue)
-                return issues
+                    for idx, identifier in enumerate(self.get_iterative_list())
+                ]
             elif self.does_issue_exist():
                 issue = {
                     'description': self.generate_description(-1),
@@ -204,5 +249,5 @@ class LintRule(bpy.types.PropertyGroup):
                     'category_icon': self.category_icon,
                     'fix_expr': self.fix_expr
                 }
-                return [issue]
-        return []
+                result = [issue]
+        return result

--- a/operators/issue_fix.py
+++ b/operators/issue_fix.py
@@ -13,10 +13,30 @@
 #     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
+import os
 
 import bpy
 
+from ..model.lint_rule import import_from_file
+
 log = logging.getLogger(__name__)
+
+
+def run_fix(issue):
+    if issue.rule_file:
+        rule_file = bpy.path.abspath(issue.rule_file)
+        if not os.path.isfile(rule_file):
+            raise FileNotFoundError(rule_file)
+
+        rule_module = import_from_file(rule_file)
+        if not hasattr(rule_module, 'fix_issues') or not callable(rule_module.fix_issues):
+            raise AttributeError(obj=rule_module, name='fix_issues')
+
+        rule_module.fix_issues(issue.fix_expr)
+    else:
+        fix = issue.fix_expr
+        log.debug('Running: {}'.format(fix))
+        exec(fix)
 
 
 class BT_OT_FixIssue(bpy.types.Operator):
@@ -43,9 +63,10 @@ class BT_OT_FixIssue(bpy.types.Operator):
     def execute(self, context):
         wm = context.window_manager
         idx = wm.lint_issue_active
-        fix = wm.lint_issues[idx].fix_expr
-        log.debug('Running: {}'.format(fix))
-        exec(fix)
+        try:
+            run_fix(wm.lint_issues[idx])
+        except Exception as e:
+            self.report({'ERROR'}, str(e))
         return {'FINISHED'}
 
 
@@ -73,8 +94,10 @@ class BT_OT_DebugFixIssue(bpy.types.Operator):
     def execute(self, context):
         wm = context.window_manager
         idx = wm.blint_form_issue_active
-        fix = wm.blint_form_issues[idx].fix_expr
-        exec(fix)
+        try:
+            run_fix(wm.blint_form_issues[idx])
+        except Exception as e:
+            self.report({'ERROR'}, str(e))
         return {'FINISHED'}
 
 
@@ -101,10 +124,12 @@ class BT_OT_FixIssueAll(bpy.types.Operator):
     def execute(self, context):
         wm = context.window_manager
         for idx in range(len(wm.lint_issues)):
-            fix = wm.lint_issues[idx].fix_expr
-            if not fix:
+            if not wm.lint_issues[idx].fix_expr:
                 continue
-            log.debug('Running: {}'.format(fix))
-            exec(fix)
+
+            try:
+                run_fix(wm.lint_issues[idx])
+            except Exception as e:
+                self.report({'ERROR'}, str(e))
 
         return {'FINISHED'}

--- a/preferences/preferences.py
+++ b/preferences/preferences.py
@@ -157,6 +157,7 @@ def draw_rule_creation(layout, context, preferences):
                 new_issue.severity_icon = issue.get('severity_icon')
                 new_issue.category_icon = issue.get('category_icon')
                 new_issue.fix_expr = issue.get('fix_expr')
+                new_issue.rule_file = issue.get('rule_file', '')
             except ValueError as ex:
                 raise ValueError("Error with {}: {}".format(issue.get('description'), ex))
 
@@ -174,6 +175,11 @@ def draw_rule_creation(layout, context, preferences):
     layout.separator()
 
     layout.prop(form_rule, 'description')
+
+    layout.separator()
+    layout.prop(form_rule, 'rule_file', text='Python File')
+    layout.separator()
+
     layout.prop(form_rule, 'prop_label_expr', text='Issue identifier (optional)')
     layout.prop(form_rule, 'issue_expr', text='An issue exists if')
     layout.prop(form_rule, 'fix_expr', text='Issue fix (optional)')

--- a/save_load/reload.py
+++ b/save_load/reload.py
@@ -34,6 +34,7 @@ def reload_issues(context):
                 new_issue.severity_icon = issue.get('severity_icon')
                 new_issue.category_icon = issue.get('category_icon')
                 new_issue.fix_expr = issue.get('fix_expr')
+                new_issue.rule_file = issue.get('rule_file', '')
             except ValueError as e:
                 log.error("Error with {}: {}".format(issue.get('description'), e))
 

--- a/save_load/save_load_util.py
+++ b/save_load/save_load_util.py
@@ -66,6 +66,11 @@ def import_lint_rules(lint_rules: list[dict], rule_properties: bpy.props.Collect
             new_rule.enabled = False
         else:
             new_rule.enabled = rule.get('enabled', True)
+
+        new_rule.rule_file = rule.get('rule_file', '')
+        if new_rule.rule_file:
+            continue
+
         new_rule.severity_icon = rule.get('severity_icon', 'INFO')
         new_rule.category_icon = rule.get('category_icon')
         new_rule.issue_expr = rule.get('issue_expr')
@@ -87,19 +92,26 @@ def save_external_rules(context):
     external_rules = []
 
     for rule in lint_collection.values():
-        new_rule = {
-            'description': rule.description,
-            'enabled': rule.enabled,
-            'severity_icon': rule.severity_icon,
-            'category_icon': rule.category_icon,
-            'issue_expr': rule.issue_expr,
-            'prop_label_expr': rule.prop_label_expr,
-        }
-        if rule.fix_expr:
-            new_rule['fix_expr'] = rule.fix_expr
-        if rule.iterable_expr:
-            new_rule['iterable_expr'] = rule.iterable_expr
-            new_rule['iterable_var'] = rule.iterable_var
+        if rule.rule_file:
+            new_rule = {
+                'description': rule.description,
+                'enabled': rule.enabled,
+                'rule_file': rule.rule_file,
+            }
+        else:
+            new_rule = {
+                'description': rule.description,
+                'enabled': rule.enabled,
+                'severity_icon': rule.severity_icon,
+                'category_icon': rule.category_icon,
+                'issue_expr': rule.issue_expr,
+                'prop_label_expr': rule.prop_label_expr,
+            }
+            if rule.fix_expr:
+                new_rule['fix_expr'] = rule.fix_expr
+            if rule.iterable_expr:
+                new_rule['iterable_expr'] = rule.iterable_expr
+                new_rule['iterable_var'] = rule.iterable_var
         external_rules.append(new_rule)
 
     with open(filepath, 'w') as f:


### PR DESCRIPTION
Per #34, rules can now be defined in a separate Python file. Changing minor versions since it is changing rule behavior.

See `external_rule_template.py` for a code example and how to add it to a json config file.